### PR TITLE
Editorial suggestions from Benjamin Kaduk's IESG evaluation

### DIFF
--- a/draft-ietf-regext-epp-registry-maintenance.txt
+++ b/draft-ietf-regext-epp-registry-maintenance.txt
@@ -129,7 +129,7 @@ Internet-Draft           EPP Registry Maintenance         September 2021
 
    This document describes an extension mapping for version 1.0 of the
    Extensible Provision Protocol (EPP), as defined in [RFC5730], to
-   provide a mechanism by which EPP servers may notify EPP clients and
+   provide a mechanism by which EPP servers may notify EPP clients of and
    allow EPP clients to query EPP servers on upcoming maintenance
    events.
 
@@ -193,7 +193,7 @@ Internet-Draft           EPP Registry Maintenance         September 2021
 
 3.1.  Internationalized Domain Names
 
-   Names of affected hosts MUST be provided as an A-label according to
+   Names of affected hosts MUST be provided in A-label form, according to
    [RFC5891].
 
 3.2.  Dates and Times
@@ -207,7 +207,7 @@ Internet-Draft           EPP Registry Maintenance         September 2021
 
    The <maint:item> element describes a single registry maintenance
    event during a specific period. This element is used in a maintenance
-   item EPP <info> response and <poll> message.
+   item EPP <info> response and <poll> response.
    
    If an element is not marked as optional, it is mandatory.
 
@@ -226,7 +226,7 @@ Sattler, et al.          Expires December 17, 2021              [Page 4]
 
 Internet-Draft           EPP Registry Maintenance         September 2021
 
-      Zero or more OPTIONAL types of the maintenance event that has the
+      Zero or more OPTIONAL types of the maintenance event, with the
       possible set of values defined by server policy, such as
       "Routine Maintenance", "Software Update", "Software Upgrade", or
       "Extended Outage".
@@ -299,8 +299,8 @@ Internet-Draft           EPP Registry Maintenance         September 2021
 
    <maint:description>
       Zero or more OPTIONAL free-form descriptions of the maintenance
-      event without having to create and traverse an external resource
-      defined by the <maint:detail> element. The OPTIONAL "lang"
+      event, usable without having to create and traverse an external resource
+      as defined by the <maint:detail> element. The OPTIONAL "lang"
       attribute MAY be present to identify the language if the
       negotiated value is something other than the default value of "en"
       (English). The OPTIONAL "type" attribute MAY be present to
@@ -483,7 +483,7 @@ Internet-Draft           EPP Registry Maintenance         September 2021
 
    The information for a list of maintenance items can be retrieved by
    using the <info> command with the <maint:info> element and the empty
-   <maint:list> child element. Server policy determines if previous
+   <maint:list> child element. Server policy determines if completed
    maintenance events will be included in the list of maintenance items.
 
    Example to retrieve the list of maintenance items in an <info>
@@ -580,7 +580,7 @@ Sattler, et al.          Expires December 17, 2021             [Page 10]
 
 Internet-Draft           EPP Registry Maintenance         September 2021
 
-   3.3. A poll message applies when a maintenance event is created,
+   3.3. A poll message might be generated when a maintenance event is created,
    updated, or deleted. A courtesy poll message can be sent as a
    reminder of an impending maintenance event. An end poll message can
    be sent when the maintenance event is completed. In the case of a
@@ -1008,15 +1008,15 @@ Internet-Draft           EPP Registry Maintenance         September 2021
 
 7.  Security Considerations
 
-   The security considerations of [RFC5730] apply in this document,
-   additionally a server MUST only provide maintenance information for
+   The security considerations of [RFC5730] apply in this document.
+   Additionally, a server MUST only provide maintenance information for
    clients that are authorized. If a client queries for a maintenance
    identifier, per Section 4.1.3.1 "Info Maintenance Item", that it is
    not authorized to access, the server MUST return an EPP error result
    code of 2201 [RFC5730]. The list of top-level domains or registry
    zones returned in the "Info Maintenance Item" response SHOULD be
    filtered based on the top-level domains or registry zones the client
-   is authorized. Authorization of poll messages is done at the time of
+   is authorized for. Authorization of poll messages is done at the time of
    poll message insertion and not at the time of poll message
    consumption.
 

--- a/draft-ietf-regext-epp-registry-maintenance.txt
+++ b/draft-ietf-regext-epp-registry-maintenance.txt
@@ -167,7 +167,9 @@ Internet-Draft           EPP Registry Maintenance         September 2021
 
    Servers that implement this extension SHOULD provide a way for
    clients to progressively update their implementations when a new
-   version of the extension is deployed.
+   version of the extension is deployed.  A newer version of the
+   extension is expected to use an XML namespace with a higher version
+   number than the prior versions.
    
    Servers SHOULD (for a temporary migration period up to server policy)
    provide support for older versions of the extension in parallel to

--- a/draft-ietf-regext-epp-registry-maintenance.txt
+++ b/draft-ietf-regext-epp-registry-maintenance.txt
@@ -148,7 +148,7 @@ Internet-Draft           EPP Registry Maintenance         September 2021
 
    "maint" is used as an abbreviation for "urn:ietf:params:xml:ns:epp:
    maintenance-1.0". The XML namespace prefix "maint" is used, but
-   implementations MUST NOT depend on it and instead employ a proper
+   implementations MUST NOT depend on it. Instead, they are to employ a proper
    namespace-aware XML parser and serializer to interpret and output
    the XML documents.
    


### PR DESCRIPTION
There were a couple places where we talk about topics (XML namespaces, etc.) in a way that is shared by many EPP documents.  On the assumption that there is a conventional phrasing, I picked an arbitrary document  as reference (RFC 8807) and attempted to converge with its phrasing (though I did not achieve full convergence with just these changes).  Those changes are in separate commits for ease of removal if my assumption proves ill-founded.